### PR TITLE
SettlementUtils interface update

### DIFF
--- a/contracts/DarknodeSlasher.sol
+++ b/contracts/DarknodeSlasher.sol
@@ -47,7 +47,6 @@ contract DarknodeSlasher is Ownable {
         uint256 minimumVolume
     ) external onlyDarknode {
         SettlementUtils.OrderDetails memory order = SettlementUtils.OrderDetails({
-            details: details,
             settlementID: settlementID,
             tokens: tokens,
             price: price,
@@ -56,7 +55,7 @@ contract DarknodeSlasher is Ownable {
         });
 
         // Hash the order
-        bytes32 orderID = SettlementUtils.hashOrder(order);
+        bytes32 orderID = SettlementUtils.hashOrder(details, order);
 
         // Check the order details haven't already been submitted
         require(!orderSubmitted[orderID], "already submitted");

--- a/contracts/SettlementUtils.sol
+++ b/contracts/SettlementUtils.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.4.24;
 library SettlementUtils {
 
     struct OrderDetails {
-        bytes details;
         uint64 settlementID;
         uint64 tokens;
         uint256 price;
@@ -13,11 +12,12 @@ library SettlementUtils {
     }
 
     /// @notice Calculates the ID of the order
+    /// @param details ...
     /// @param order the order to hash
-    function hashOrder(OrderDetails order) internal pure returns (bytes32) {
+    function hashOrder(bytes details, OrderDetails memory order) internal pure returns (bytes32) {
         return keccak256(
             abi.encodePacked(
-                order.details,
+                details,
                 order.settlementID,
                 order.tokens,
                 order.price,
@@ -36,7 +36,7 @@ library SettlementUtils {
     ///   2) verify the orders' traders are distinct
     /// @param _buy The buy order details.
     /// @param _sell The sell order details.
-    function verifyMatchDetails(OrderDetails _buy, OrderDetails _sell) internal pure returns (bool) {
+    function verifyMatchDetails(OrderDetails memory _buy, OrderDetails memory _sell) internal pure returns (bool) {
 
         // Buy and sell tokens should match
         if (!verifyTokens(_buy.tokens, _sell.tokens)) {
@@ -66,12 +66,14 @@ library SettlementUtils {
         return true;
     }
 
-    /// @notice Verifies that two token requirements can be matched.
+    /// @notice Verifies that two token requirements can be matched and that the
+    /// tokens are formatted correctly.
     /// @param _buyTokens The buy token details.
     /// @param _sellToken The sell token details.
     function verifyTokens(uint64 _buyTokens, uint64 _sellToken) internal pure returns (bool) {
         return (uint32(_buyTokens) == uint32(_sellToken >> 32) &&
-                uint32(_sellToken) == uint32(_buyTokens >> 32)
+                uint32(_sellToken) == uint32(_buyTokens >> 32) &&
+                uint32(_buyTokens >> 32) <= uint32(_buyTokens)
         );
     }
 }

--- a/contracts/SettlementUtils.sol
+++ b/contracts/SettlementUtils.sol
@@ -11,9 +11,10 @@ library SettlementUtils {
         uint256 minimumVolume;
     }
 
-    /// @notice Calculates the ID of the order
-    /// @param details ...
-    /// @param order the order to hash
+    /// @notice Calculates the ID of the order.
+    /// @param details Order details that are not required for settlement
+    ///        execution. They are combined as a single byte array.
+    /// @param order The order details required for settlement execution.
     function hashOrder(bytes details, OrderDetails memory order) internal pure returns (bytes32) {
         return keccak256(
             abi.encodePacked(

--- a/contracts/tests/SettlementUtilsTest.sol
+++ b/contracts/tests/SettlementUtilsTest.sol
@@ -16,14 +16,13 @@ contract SettlementUtilsTest {
         uint256 minimumVolume
     ) public {
         SettlementUtils.OrderDetails memory order = SettlementUtils.OrderDetails({
-            details: details,
             settlementID: settlementID,
             tokens: tokens,
             price: price,
             volume: volume,
             minimumVolume: minimumVolume
         });
-        bytes32 orderID = SettlementUtils.hashOrder(order);
+        bytes32 orderID = SettlementUtils.hashOrder(details, order);
         orderDetails[orderID] = order;
     }
 
@@ -36,14 +35,13 @@ contract SettlementUtilsTest {
         uint256 minimumVolume
     ) public pure returns (bytes32) {
         SettlementUtils.OrderDetails memory order = SettlementUtils.OrderDetails({
-            details: details,
             settlementID: settlementID,
             tokens: tokens,
             price: price,
             volume: volume,
             minimumVolume: minimumVolume
         });
-        return SettlementUtils.hashOrder(order);
+        return SettlementUtils.hashOrder(details, order);
     }
 
     function verifyMatchDetails(bytes32 _buyID, bytes32 _sellID) public view returns (bool) {


### PR DESCRIPTION
This PR adds two small updates to the SettlementUtils library:

1) The `details` field is passed in separately to the `hashOrder` function. This helps keep the `details`, which isn't stored after hashing, separate from the other order details, which are.
2) The `verifyTokens` function also checks that the tokens are formatted correctly (the buy tokens have the priority token followed by the secondary token, and vice versa for the sell tokens).