### PR TITLE
Cap darknode bonds to the minimum bond

### DIFF
--- a/contracts/test/Reverter.sol
+++ b/contracts/test/Reverter.sol
@@ -13,7 +13,7 @@ contract Reverter {
         // REN allowance
         require(ren.transferFrom(msg.sender, this, _bond), "bond transfer failed");
         ren.approve(dnr, _bond);
-        dnr.register(_darknodeID, _publicKey, _bond);
+        dnr.register(_darknodeID, _publicKey);
     }
 
     function () public payable {

--- a/test-ts/DarknodeRegistry.ts
+++ b/test-ts/DarknodeRegistry.ts
@@ -77,8 +77,7 @@ contract("DarknodeRegistry", (accounts: string[]) => {
     it("can not register a Dark Node with a bond less than the minimum bond", async () => {
         const lowBond = MINIMUM_BOND.sub(new BN(1));
         await ren.approve(dnr.address, lowBond, { from: accounts[0] });
-        await dnr.register(ID("A"), PUBK("A"), lowBond).should.be.rejectedWith(null, /insufficient bond/);
-        await dnr.register(ID("A"), PUBK("A"), MINIMUM_BOND).should.be.rejectedWith(null, /revert/); // failed transfer
+        await dnr.register(ID("A"), PUBK("A")).should.be.rejectedWith(null, /revert/); // failed transfer
     });
 
     it("can not call epoch before the minimum time interval", async () => {
@@ -87,24 +86,189 @@ contract("DarknodeRegistry", (accounts: string[]) => {
         await dnr.epoch().should.be.rejectedWith(null, /revert/);
     });
 
-    it("can register multiple Dark Nodes and check registration", async () => {
+    it("can register, deregister and refund Darknodes", async () => {
+        // [ACTION] Register
         for (let i = 0; i < accounts.length; i++) {
             await ren.approve(dnr.address, MINIMUM_BOND, { from: accounts[i] });
-            await dnr.register(ID(`${i + 1}`), PUBK(`${i + 1}`), MINIMUM_BOND, { from: accounts[i] });
-        }
-        for (let i = 0; i < accounts.length; i++) {
-            (await dnr.isPendingRegistration(ID(`${i + 1}`))).should.be.true;
+            await dnr.register(ID(i), PUBK(i), { from: accounts[i] });
         }
 
+        // Wait for epoch
         await waitForEpoch(dnr);
+
+        // [ACTION] Deregister
         for (let i = 0; i < accounts.length; i++) {
-            (await dnr.isRegistered(ID(`${i + 1}`))).should.be.true;
+            await dnr.deregister(ID(i), { from: accounts[i] });
         }
+
+        // Wait for two epochs
+        await waitForEpoch(dnr);
+        await waitForEpoch(dnr);
+
+        // [ACTION] Refund
+        for (let i = 0; i < accounts.length; i++) {
+            await dnr.refund(ID(i), { from: accounts[i] });
+        }
+    });
+
+    it("can check darknode statuses", async () => {
+        // WARNING: A lot of code a head
+
+        const owner = accounts[2];
+        const id = ID("0");
+        const pubk = PUBK("0");
+
+        // [SETUP] Wait for epoch to reset `isRegisteredInPreviousEpoch`
+        await waitForEpoch(dnr);
+
+        // [CHECK]
+        (await dnr.isRefunded(id))
+            .should.be.true;
+        (await dnr.isPendingRegistration(id)).should.be.false;
+        (await dnr.isRegistered(id)).should.be.false;
+        (await dnr.isDeregisterable(id)).should.be.false;
+        (await dnr.isPendingDeregistration(id)).should.be.false;
+        (await dnr.isDeregistered(id)).should.be.false;
+        (await dnr.isRefundable(id)).should.be.false;
+        (await dnr.isRegisteredInPreviousEpoch(id)).should.be.false;
+
+        // [ACTION] Register
+        await ren.approve(dnr.address, MINIMUM_BOND, { from: owner });
+        await dnr.register(id, pubk, { from: owner });
+
+        // [CHECK]
+        (await dnr.isRefunded(id)).should.be.false;
+        (await dnr.isPendingRegistration(id))
+            .should.be.true;
+        (await dnr.isRegistered(id)).should.be.false;
+        (await dnr.isDeregisterable(id)).should.be.false;
+        (await dnr.isPendingDeregistration(id)).should.be.false;
+        (await dnr.isDeregistered(id)).should.be.false;
+        (await dnr.isRefundable(id)).should.be.false;
+        (await dnr.isRegisteredInPreviousEpoch(id)).should.be.false;
+
+        await waitForEpoch(dnr);
+
+        // [CHECK]
+        (await dnr.isRefunded(id)).should.be.false;
+        (await dnr.isPendingRegistration(id)).should.be.false;
+        (await dnr.isRegistered(id))
+            .should.be.true;
+        (await dnr.isDeregisterable(id))
+            .should.be.true;
+        (await dnr.isPendingDeregistration(id)).should.be.false;
+        (await dnr.isDeregistered(id)).should.be.false;
+        (await dnr.isRefundable(id)).should.be.false;
+        (await dnr.isRegisteredInPreviousEpoch(id)).should.be.false;
+
+        await waitForEpoch(dnr);
+
+        // [CHECK]
+        (await dnr.isRefunded(id)).should.be.false;
+        (await dnr.isPendingRegistration(id)).should.be.false;
+        (await dnr.isRegistered(id))
+            .should.be.true;
+        (await dnr.isDeregisterable(id))
+            .should.be.true;
+        (await dnr.isPendingDeregistration(id)).should.be.false;
+        (await dnr.isDeregistered(id)).should.be.false;
+        (await dnr.isRefundable(id)).should.be.false;
+        (await dnr.isRegisteredInPreviousEpoch(id))
+            .should.be.true;
+
+        // [ACTION] Deregister
+        await dnr.deregister(id, { from: owner });
+
+        // [CHECK]
+        (await dnr.isRefunded(id)).should.be.false;
+        (await dnr.isPendingRegistration(id)).should.be.false;
+        (await dnr.isRegistered(id))
+            .should.be.true;
+        (await dnr.isDeregisterable(id)).should.be.false;
+        (await dnr.isPendingDeregistration(id))
+            .should.be.true;
+        (await dnr.isDeregistered(id)).should.be.false;
+        (await dnr.isRefundable(id)).should.be.false;
+        (await dnr.isRegisteredInPreviousEpoch(id))
+            .should.be.true;
+
+        // [ACTION] Wait for epoch
+        await waitForEpoch(dnr);
+
+        (await dnr.isRefunded(id)).should.be.false;
+        (await dnr.isPendingRegistration(id)).should.be.false;
+        (await dnr.isRegistered(id)).should.be.false;
+        (await dnr.isDeregisterable(id)).should.be.false;
+        (await dnr.isPendingDeregistration(id)).should.be.false;
+        (await dnr.isDeregistered(id))
+            .should.be.true;
+        (await dnr.isRefundable(id)).should.be.false;
+        (await dnr.isRegisteredInPreviousEpoch(id))
+            .should.be.true;
+
+        // [ACTION] Wait for epoch
+        await waitForEpoch(dnr);
+
+        (await dnr.isRefunded(id)).should.be.false;
+        (await dnr.isPendingRegistration(id)).should.be.false;
+        (await dnr.isRegistered(id)).should.be.false;
+        (await dnr.isDeregisterable(id)).should.be.false;
+        (await dnr.isPendingDeregistration(id)).should.be.false;
+        (await dnr.isDeregistered(id))
+            .should.be.true;
+        (await dnr.isRefundable(id))
+            .should.be.true;
+        (await dnr.isRegisteredInPreviousEpoch(id)).should.be.false;
+
+        // [ACTION] Refund
+        await dnr.refund(id, { from: accounts[0] });
+
+        (await dnr.isRefunded(id))
+            .should.be.true;
+        (await dnr.isPendingRegistration(id)).should.be.false;
+        (await dnr.isRegistered(id)).should.be.false;
+        (await dnr.isDeregisterable(id)).should.be.false;
+        (await dnr.isPendingDeregistration(id)).should.be.false;
+        (await dnr.isDeregistered(id)).should.be.false;
+        (await dnr.isRefundable(id)).should.be.false;
+        (await dnr.isRegisteredInPreviousEpoch(id)).should.be.false;
+    });
+
+    it("bond is exactly the minimum bond", async () => {
+        const owner = accounts[2];
+        const id = ID("0");
+        const pubk = PUBK("0");
+
+        const renBalanceBefore = new BN(await ren.balanceOf(owner));
+
+        // Approve more than minimum bond
+        await ren.approve(dnr.address, MINIMUM_BOND.mul(new BN(2)), { from: owner });
+
+        // Register
+        await dnr.register(id, pubk, { from: owner });
+
+        // Only minimum bond should have been transferred
+        (await ren.balanceOf(owner)).should.bignumber.equal(renBalanceBefore.sub(MINIMUM_BOND));
+
+        // [RESET]
+        await waitForEpoch(dnr);
+        await dnr.deregister(id, { from: owner });
+        await waitForEpoch(dnr);
+        await waitForEpoch(dnr);
+        await dnr.refund(id, { from: owner });
+    });
+
+    it("[SETUP] Register darknodes for next tests", async () => {
+        for (let i = 0; i < accounts.length; i++) {
+            await ren.approve(dnr.address, MINIMUM_BOND, { from: accounts[i] });
+            await dnr.register(ID(i), PUBK(i), { from: accounts[i] });
+        }
+        await dnr.epoch();
     });
 
     it("can not register a node twice", async () => {
         await ren.approve(dnr.address, MINIMUM_BOND, { from: accounts[0] });
-        await dnr.register(ID("1"), PUBK("1"), MINIMUM_BOND)
+        await dnr.register(ID("0"), PUBK("0"))
             .should.be.rejectedWith(null, /must be refunded or never registered/);
     });
 
@@ -113,48 +277,48 @@ contract("DarknodeRegistry", (accounts: string[]) => {
     });
 
     it("only darknode owner can deregister darknode", async () => {
-        await dnr.deregister(ID("1"), { from: accounts[9] }).should.be.rejectedWith(null, /must be darknode owner/);
+        await dnr.deregister(ID("0"), { from: accounts[9] }).should.be.rejectedWith(null, /must be darknode owner/);
     });
 
     it("can get the owner of the Dark Node", async () => {
-        (await dnr.getDarknodeOwner(ID("1"))).should.equal(accounts[0]);
+        (await dnr.getDarknodeOwner(ID("0"))).should.equal(accounts[0]);
     });
 
     it("can get the bond of the Dark Node", async () => {
-        (await dnr.getDarknodeBond(ID("1"))).should.bignumber.equal(MINIMUM_BOND);
+        (await dnr.getDarknodeBond(ID("0"))).should.bignumber.equal(MINIMUM_BOND);
     });
 
     it("can get the Public Key of the Dark Node", async () => {
-        (await dnr.getDarknodePublicKey(ID("1"))).should.equal(PUBK("1"));
+        (await dnr.getDarknodePublicKey(ID("0"))).should.equal(PUBK("0"));
     });
 
     it("can deregister dark nodes", async () => {
-        await dnr.deregister(ID("1"), { from: accounts[0] });
-        await dnr.deregister(ID("2"), { from: accounts[1] });
-        await dnr.deregister(ID("5"), { from: accounts[4] });
-        await dnr.deregister(ID("6"), { from: accounts[5] });
-        await dnr.deregister(ID("9"), { from: accounts[8] });
-        await dnr.deregister(ID("10"), { from: accounts[9] });
+        await dnr.deregister(ID("0"), { from: accounts[0] });
+        await dnr.deregister(ID("1"), { from: accounts[1] });
+        await dnr.deregister(ID("4"), { from: accounts[4] });
+        await dnr.deregister(ID("5"), { from: accounts[5] });
+        await dnr.deregister(ID("8"), { from: accounts[8] });
+        await dnr.deregister(ID("9"), { from: accounts[9] });
         await waitForEpoch(dnr);
+        (await dnr.isDeregistered(ID("0"))).should.be.true;
         (await dnr.isDeregistered(ID("1"))).should.be.true;
-        (await dnr.isDeregistered(ID("2"))).should.be.true;
+        (await dnr.isDeregistered(ID("4"))).should.be.true;
         (await dnr.isDeregistered(ID("5"))).should.be.true;
-        (await dnr.isDeregistered(ID("6"))).should.be.true;
+        (await dnr.isDeregistered(ID("8"))).should.be.true;
         (await dnr.isDeregistered(ID("9"))).should.be.true;
-        (await dnr.isDeregistered(ID("10"))).should.be.true;
     });
 
     it("can't deregister twice", async () => {
-        await dnr.deregister(ID("1"), { from: accounts[0] }).should.be.rejectedWith(null, /must be deregisterable/);
+        await dnr.deregister(ID("0"), { from: accounts[0] }).should.be.rejectedWith(null, /must be deregisterable/);
     });
 
     it("can get the current epoch's registered dark nodes", async () => {
         const nodes = (await dnr.getDarknodes(NULL, 0)).filter((x) => x !== NULL);
         (nodes.length).should.equal(accounts.length - 6);
-        nodes[0].should.equal(ID("3"));
-        nodes[1].should.equal(ID("4"));
-        nodes[2].should.equal(ID("7"));
-        nodes[3].should.equal(ID("8"));
+        nodes[0].should.equal(ID("2"));
+        nodes[1].should.equal(ID("3"));
+        nodes[2].should.equal(ID("6"));
+        nodes[3].should.equal(ID("7"));
     });
 
     it("can get the previous epoch's registered dark nodes", async () => {
@@ -182,10 +346,10 @@ contract("DarknodeRegistry", (accounts: string[]) => {
         } while (start !== NULL);
 
         (nodes.length).should.equal(accounts.length - 6);
-        nodes[0].should.equal(ID("3"));
-        nodes[1].should.equal(ID("4"));
-        nodes[2].should.equal(ID("7"));
-        nodes[3].should.equal(ID("8"));
+        nodes[0].should.equal(ID("2"));
+        nodes[1].should.equal(ID("3"));
+        nodes[2].should.equal(ID("6"));
+        nodes[3].should.equal(ID("7"));
     });
 
     it("can get the previous epoch's dark nodes in multiple calls", async () => {
@@ -203,58 +367,58 @@ contract("DarknodeRegistry", (accounts: string[]) => {
         } while (start !== NULL);
 
         (nodes.length).should.equal(accounts.length - 6);
-        nodes[0].should.equal(ID("3"));
-        nodes[1].should.equal(ID("4"));
-        nodes[2].should.equal(ID("7"));
-        nodes[3].should.equal(ID("8"));
+        nodes[0].should.equal(ID("2"));
+        nodes[1].should.equal(ID("3"));
+        nodes[2].should.equal(ID("6"));
+        nodes[3].should.equal(ID("7"));
     });
 
     it("should fail to refund before deregistering", async () => {
-        await dnr.refund(ID("4"), { from: accounts[3] }).should.be.rejectedWith(null, /must be deregistered/);
+        await dnr.refund(ID("3"), { from: accounts[3] }).should.be.rejectedWith(null, /must be deregistered/);
     });
 
     it("can deregister and refund dark nodes", async () => {
         // Deregister
-        await dnr.deregister(ID("3"), { from: accounts[2] });
-        await dnr.deregister(ID("4"), { from: accounts[3] });
-        await dnr.deregister(ID("7"), { from: accounts[6] });
-        await dnr.deregister(ID("8"), { from: accounts[7] });
+        await dnr.deregister(ID("2"), { from: accounts[2] });
+        await dnr.deregister(ID("3"), { from: accounts[3] });
+        await dnr.deregister(ID("6"), { from: accounts[6] });
+        await dnr.deregister(ID("7"), { from: accounts[7] });
 
+        (await dnr.isPendingDeregistration(ID("2"))).should.be.true;
         (await dnr.isPendingDeregistration(ID("3"))).should.be.true;
-        (await dnr.isPendingDeregistration(ID("4"))).should.be.true;
+        (await dnr.isPendingDeregistration(ID("6"))).should.be.true;
         (await dnr.isPendingDeregistration(ID("7"))).should.be.true;
-        (await dnr.isPendingDeregistration(ID("8"))).should.be.true;
 
         // Call epoch
         await waitForEpoch(dnr);
 
+        (await dnr.isRegisteredInPreviousEpoch(ID("2"))).should.be.true;
         (await dnr.isRegisteredInPreviousEpoch(ID("3"))).should.be.true;
-        (await dnr.isRegisteredInPreviousEpoch(ID("4"))).should.be.true;
+        (await dnr.isRegisteredInPreviousEpoch(ID("6"))).should.be.true;
         (await dnr.isRegisteredInPreviousEpoch(ID("7"))).should.be.true;
-        (await dnr.isRegisteredInPreviousEpoch(ID("8"))).should.be.true;
+        (await dnr.isDeregistered(ID("2"))).should.be.true;
         (await dnr.isDeregistered(ID("3"))).should.be.true;
-        (await dnr.isDeregistered(ID("4"))).should.be.true;
+        (await dnr.isDeregistered(ID("6"))).should.be.true;
         (await dnr.isDeregistered(ID("7"))).should.be.true;
-        (await dnr.isDeregistered(ID("8"))).should.be.true;
         const previousDarknodesEpoch1 = (await dnr.getPreviousDarknodes(NULL, 0)).filter((x) => x !== NULL);
         await waitForEpoch(dnr);
         const previousDarknodesEpoch2 = (await dnr.getPreviousDarknodes(NULL, 0)).filter((x) => x !== NULL);
         (previousDarknodesEpoch1.length - previousDarknodesEpoch2.length).should.be.equal(4);
+        (await dnr.isDeregistered(ID("2"))).should.be.true;
         (await dnr.isDeregistered(ID("3"))).should.be.true;
-        (await dnr.isDeregistered(ID("4"))).should.be.true;
+        (await dnr.isDeregistered(ID("6"))).should.be.true;
         (await dnr.isDeregistered(ID("7"))).should.be.true;
-        (await dnr.isDeregistered(ID("8"))).should.be.true;
 
         // Refund
-        await dnr.refund(ID("3"), { from: accounts[2] });
-        await dnr.refund(ID("4"), { from: accounts[3] });
-        await dnr.refund(ID("7"), { from: accounts[6] });
-        await dnr.refund(ID("8"), { from: accounts[7] });
+        await dnr.refund(ID("2"), { from: accounts[2] });
+        await dnr.refund(ID("3"), { from: accounts[3] });
+        await dnr.refund(ID("6"), { from: accounts[6] });
+        await dnr.refund(ID("7"), { from: accounts[7] });
 
+        (await dnr.isRefunded(ID("2"))).should.be.true;
         (await dnr.isRefunded(ID("3"))).should.be.true;
-        (await dnr.isRefunded(ID("4"))).should.be.true;
+        (await dnr.isRefunded(ID("6"))).should.be.true;
         (await dnr.isRefunded(ID("7"))).should.be.true;
-        (await dnr.isRefunded(ID("8"))).should.be.true;
         (await ren.balanceOf(accounts[2])).should.bignumber.equal(MINIMUM_BOND);
         (await ren.balanceOf(accounts[3])).should.bignumber.equal(MINIMUM_BOND);
         (await ren.balanceOf(accounts[6])).should.bignumber.equal(MINIMUM_BOND);
@@ -263,12 +427,12 @@ contract("DarknodeRegistry", (accounts: string[]) => {
 
     it("anyone can refund", async () => {
         const owner = accounts[2];
-        const id = ID("3");
-        const pubk = PUBK("3");
+        const id = ID("2");
+        const pubk = PUBK("2");
 
         // [SETUP] Register and then deregister nodes
         await ren.approve(dnr.address, MINIMUM_BOND, { from: owner });
-        await dnr.register(id, pubk, MINIMUM_BOND, { from: owner });
+        await dnr.register(id, pubk, { from: owner });
         await waitForEpoch(dnr);
         await dnr.deregister(id, { from: owner });
         (await dnr.isPendingDeregistration(id)).should.be.true;
@@ -284,26 +448,26 @@ contract("DarknodeRegistry", (accounts: string[]) => {
     });
 
     it("should fail to refund twice", async () => {
-        await dnr.refund(ID("3")).should.be.rejectedWith(null, /must be deregistered for at least one epoch/);
+        await dnr.refund(ID("2")).should.be.rejectedWith(null, /must be deregistered for at least one epoch/);
     });
 
     it("should throw if refund fails", async () => {
         // [SETUP]
         await ren.approve(dnr.address, MINIMUM_BOND, { from: accounts[0] });
-        await dnr.register(ID("3"), PUBK("3"), MINIMUM_BOND);
+        await dnr.register(ID("2"), PUBK("2"));
         await waitForEpoch(dnr);
-        await dnr.deregister(ID("3"));
+        await dnr.deregister(ID("2"));
         await waitForEpoch(dnr);
         await waitForEpoch(dnr);
         await waitForEpoch(dnr);
 
         // [CHECK] Refund fails if transfer fails
         await ren.pause();
-        await dnr.refund(ID("3")).should.be.rejectedWith(null, /revert/); // paused contract
+        await dnr.refund(ID("2")).should.be.rejectedWith(null, /revert/); // paused contract
         await ren.unpause();
 
         // [RESET]
-        await dnr.refund(ID("3"));
+        await dnr.refund(ID("2"));
     });
 
     it("should not refund for an address which is never registered", async () => {
@@ -339,6 +503,7 @@ contract("DarknodeRegistry", (accounts: string[]) => {
         // [SETUP] Set slasher to accounts[3]
         const previousSlasher = await dnr.slasher();
         const slasher = accounts[3];
+        const notSlasher = accounts[4];
         await dnr.updateSlasher(slasher);
 
         // [SETUP] Register darknodes 3, 4, 7 and 8
@@ -346,20 +511,20 @@ contract("DarknodeRegistry", (accounts: string[]) => {
         await ren.approve(dnr.address, MINIMUM_BOND, { from: accounts[3] });
         await ren.approve(dnr.address, MINIMUM_BOND, { from: accounts[6] });
         await ren.approve(dnr.address, MINIMUM_BOND, { from: accounts[7] });
-        await dnr.register(ID("3"), PUBK("3"), MINIMUM_BOND, { from: accounts[2] });
-        await dnr.register(ID("4"), PUBK("4"), MINIMUM_BOND, { from: accounts[3] });
-        await dnr.register(ID("7"), PUBK("7"), MINIMUM_BOND, { from: accounts[6] });
-        await dnr.register(ID("8"), PUBK("8"), MINIMUM_BOND, { from: accounts[7] });
+        await dnr.register(ID("2"), PUBK("2"), { from: accounts[2] });
+        await dnr.register(ID("3"), PUBK("3"), { from: accounts[3] });
+        await dnr.register(ID("6"), PUBK("6"), { from: accounts[6] });
+        await dnr.register(ID("7"), PUBK("7"), { from: accounts[7] });
         await waitForEpoch(dnr);
-        await dnr.deregister(ID("4"), { from: accounts[3] });
+        await dnr.deregister(ID("3"), { from: accounts[3] });
         await waitForEpoch(dnr);
         await waitForEpoch(dnr);
 
         // [CHECK] Only the slasher can call `slash`
-        await dnr.slash(ID("3"), ID("7"), ID("8"), { from: accounts[4] })
+        await dnr.slash(ID("2"), ID("6"), ID("7"), { from: notSlasher })
             .should.be.rejectedWith(null, /must be slasher/);
-        await dnr.slash(ID("3"), ID("7"), ID("8"), { from: slasher });
-        await dnr.slash(ID("4"), ID("7"), ID("8"), { from: slasher });
+        await dnr.slash(ID("2"), ID("6"), ID("7"), { from: slasher });
+        await dnr.slash(ID("3"), ID("6"), ID("7"), { from: slasher });
 
         // [RESET] Reset slasher to the slasher contract
         await dnr.updateSlasher(previousSlasher);
@@ -454,9 +619,9 @@ contract("DarknodeRegistry", (accounts: string[]) => {
         await ren.approve(dnr.address, MINIMUM_BOND.mul(new BN(MAX_DARKNODES)));
 
         for (let i = 0; i < MAX_DARKNODES; i++) {
-            process.stdout.write(`\rRegistering Darknode #${i + 1}`);
+            process.stdout.write(`\rRegistering Darknode #${i}`);
 
-            await dnr.register(ID(`${i + 1}`), PUBK(`${i + 1}`), MINIMUM_BOND);
+            await dnr.register(ID(i), PUBK(i));
         }
 
         console.log("");
@@ -474,8 +639,8 @@ contract("DarknodeRegistry", (accounts: string[]) => {
         numDarknodes.should.bignumber.equal(MAX_DARKNODES);
 
         for (let i = 0; i < MAX_DARKNODES; i++) {
-            process.stdout.write(`\rDeregistering Darknode #${i + 1}`);
-            await dnr.deregister(ID(`${i + 1}`));
+            process.stdout.write(`\rDeregistering Darknode #${i}`);
+            await dnr.deregister(ID(i));
         }
 
         console.log("");
@@ -484,8 +649,8 @@ contract("DarknodeRegistry", (accounts: string[]) => {
         await waitForEpoch(dnr);
 
         for (let i = 0; i < MAX_DARKNODES; i++) {
-            process.stdout.write(`\rRefunding Darknode #${i + 1}`);
-            await dnr.refund(ID(`${i + 1}`));
+            process.stdout.write(`\rRefunding Darknode #${i}`);
+            await dnr.refund(ID(i));
         }
 
         console.log("");

--- a/test-ts/DarknodeRewardVault.ts
+++ b/test-ts/DarknodeRewardVault.ts
@@ -58,7 +58,7 @@ contract("DarknodeRewardVault", (accounts: string[]) => {
         for (const darknode of [darknode1, darknode2]) {
             await ren.transfer(darknodeOperator, MINIMUM_BOND);
             await ren.approve(dnr.address, MINIMUM_BOND, { from: darknodeOperator });
-            await dnr.register(darknode, "0x00", MINIMUM_BOND, { from: darknodeOperator });
+            await dnr.register(darknode, "0x00", { from: darknodeOperator });
         }
         await dnr.epoch();
 

--- a/test-ts/DarknodeSlasher.ts
+++ b/test-ts/DarknodeSlasher.ts
@@ -54,9 +54,9 @@ contract("Darknode Slasher", (accounts: string[]) => {
         await ren.approve(dnr.address, MINIMUM_BOND, { from: accounts[2] });
         await ren.approve(dnr.address, MINIMUM_BOND, { from: accounts[3] });
 
-        await dnr.register(darknode5, testUtils.PUBK("1"), MINIMUM_BOND, { from: accounts[1] });
-        await dnr.register(darknode6, testUtils.PUBK("2"), MINIMUM_BOND, { from: accounts[2] });
-        await dnr.register(darknode7, testUtils.PUBK("3"), MINIMUM_BOND, { from: accounts[3] });
+        await dnr.register(darknode5, testUtils.PUBK("1"), { from: accounts[1] });
+        await dnr.register(darknode6, testUtils.PUBK("2"), { from: accounts[2] });
+        await dnr.register(darknode7, testUtils.PUBK("3"), { from: accounts[3] });
         await testUtils.waitForEpoch(dnr);
 
         (await dnr.isRegistered(darknode5)).should.be.true;

--- a/test-ts/Orderbook.ts
+++ b/test-ts/Orderbook.ts
@@ -56,7 +56,7 @@ contract("Orderbook", (accounts: string[]) => {
         // Register all nodes
         darknode = accounts[8];
         await ren.approve(dnr.address, MINIMUM_BOND, { from: darknode });
-        await dnr.register(darknode, "0x00", MINIMUM_BOND, { from: darknode });
+        await dnr.register(darknode, "0x00", { from: darknode });
 
         await dnr.epoch();
     });

--- a/test-ts/helper/testUtils.ts
+++ b/test-ts/helper/testUtils.ts
@@ -5,6 +5,10 @@ import * as chaiBigNumber from "chai-bignumber";
 import * as crypto from "crypto";
 
 import BigNumber from "bignumber.js";
+
+import { BN } from "bn.js";
+
+import { DarknodeRegistryContract } from "../bindings/darknode_registry";
 import { OrderbookContract } from "../bindings/orderbook";
 
 // Import chai log helper
@@ -15,16 +19,18 @@ chai.use(chaiBigNumber(BigNumber));
 chai.should();
 
 const config = require("../../migrations/config.js");
-export const { MINIMUM_BOND, MINIMUM_POD_SIZE, MINIMUM_EPOCH_INTERVAL } = config;
+export const { MINIMUM_POD_SIZE, MINIMUM_EPOCH_INTERVAL } = config;
+
+export const MINIMUM_BOND = new BN(config.MINIMUM_BOND);
 
 // Makes an ID for a darknode
-export function ID(i: string) {
-    return web3.utils.toChecksumAddress(web3.utils.sha3(i).slice(0, 42));
+export function ID(i: string | number) {
+    return web3.utils.toChecksumAddress(web3.utils.sha3(i.toString()).slice(0, 42));
 }
 
 // Makes a public key for a darknode
-export function PUBK(i: string) {
-    return web3.utils.sha3(i);
+export function PUBK(i: string | number) {
+    return web3.utils.sha3(i.toString());
 }
 
 export const NULL = "0x0000000000000000000000000000000000000000";
@@ -38,7 +44,7 @@ export const randomAddress = (): string => {
     return web3.utils.toChecksumAddress(randomBytes(20));
 };
 
-export async function waitForEpoch(dnr: any) {
+export async function waitForEpoch(dnr: DarknodeRegistryContract) {
     const timeout = MINIMUM_EPOCH_INTERVAL * 0.1;
     while (true) {
         // Must be an on-chain call, or the time won't be updated

--- a/test-ts/libraries/SettlementUtils.ts
+++ b/test-ts/libraries/SettlementUtils.ts
@@ -23,7 +23,7 @@ contract("SettlementUtils", (accounts: string[]) => {
         // Register darknode
         await ren.transfer(darknode, MINIMUM_BOND);
         await ren.approve(dnr.address, MINIMUM_BOND, { from: darknode });
-        await dnr.register(darknode, PUBK("1"), MINIMUM_BOND, { from: darknode });
+        await dnr.register(darknode, PUBK("1"), { from: darknode });
         await waitForEpoch(dnr);
     });
 


### PR DESCRIPTION
**Description**

Previously, darknodes passed in a `bond` parameter to `register` to set the amount of REN locked up as the darknode's bond. The bond was able to be set to any amount greater than or equal to `minimumBond`. The parameter has been removed and `register` updated to transfer exactly `minimumBond`.

**Motivation**

There's no need for the Darknode Registry to hold more than the necessary bond amount. Removing the parameter simplifies the `register` function and reduces the gas costs of calling it.